### PR TITLE
fix: don't panic on unknown command with single arg

### DIFF
--- a/observe.go
+++ b/observe.go
@@ -135,7 +135,11 @@ func RunCommandWithConfig(cfg *Config, fs fileSystem, op Output, args []string, 
 	}
 	cmd := FindCommand(args[0])
 	if cmd == nil {
-		fmt.Fprintf(os.Stderr, "\nobserve: there is no command named %q for object type %s\n\n", args[0], args[1])
+		if len(args) > 1 {
+			fmt.Fprintf(os.Stderr, "\nobserve: there is no command named %q for object type %s\n\n", args[0], args[1])
+		} else {
+			fmt.Fprintf(os.Stderr, "\nobserve: there is no command named %q\n\n", args[0])
+		}
 		help()
 	}
 	var errors []string


### PR DESCRIPTION
## Problem

When `observe` is invoked with a single unknown argument (e.g. `observe foobar`), the binary panics with an index out-of-bounds error instead of printing a helpful error message and exiting cleanly.

## Fix

Check the length of `os.Args` before indexing into it in the command dispatch logic. Return a user-friendly error message instead of panicking.

## Testing

- Run `observe unknowncmd` — now prints an error and exits non-zero instead of panicking
- Run `observe` with no args — behaviour unchanged