### PR TITLE
feat: add opal subcommands for pipeline linting and reference

### DIFF
--- a/cmd_opal.go
+++ b/cmd_opal.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	flagsOpal       *pflag.FlagSet
+	flagOpalFile    string
+	flagOpalDataset string
+)
+
+var ErrOpalUsage = ObserveError{Msg: "usage: observe opal <check|verbs|functions|validate-ingest> [args...]"}
+
+func init() {
+	flagsOpal = pflag.NewFlagSet("opal", pflag.ContinueOnError)
+	flagsOpal.StringVarP(&flagOpalFile, "file", "f", "", "Read OPAL pipeline from file instead of argument")
+	flagsOpal.StringVar(&flagOpalDataset, "dataset", "", "Source dataset ID for validate-ingest subcommand")
+	RegisterCommand(&Command{
+		Name:  "opal",
+		Help:  "Validate and inspect OPAL pipelines and functions.",
+		Flags: flagsOpal,
+		Func:  cmdOpal,
+	})
+}
+
+func cmdOpal(fa FuncArgs) error {
+	if len(fa.args) < 2 {
+		return ErrOpalUsage
+	}
+	switch fa.args[1] {
+	case "check":
+		return cmdOpalCheck(fa)
+	case "verbs":
+		return cmdOpalVerbs(fa)
+	case "functions":
+		return cmdOpalFunctions(fa)
+	case "validate-ingest":
+		return cmdOpalValidateIngest(fa)
+	default:
+		return ObserveError{Msg: fmt.Sprintf("unknown opal subcommand %q; expected check, verbs, functions, or validate-ingest", fa.args[1])}
+	}
+}
+
+// cmdOpalVerbs and cmdOpalFunctions are implemented in ot_opal.go (issue #6).
+// cmdOpalValidateIngest is implemented in cmd_opal_validate.go (issue #7).
+
+// gqlCheckQueries validates an OPAL pipeline using the checkQueries GraphQL operation.
+//
+// Actual API schema (discovered via integration tests):
+//   - Input: MultiStageQueryInput { outputStage: String!, stages: [StageQueryInput!]! }
+//   - StageQueryInput: { stageID: String!, pipeline: String!, input: [InputDefinitionInput!]! }
+//   - Returns: [CompilationResult!]  (array, one per stage)
+//   - CompilationResult.parsedPipeline.errors: [PipelineSymbol!] { col, row, text, type }
+//   - CompilationResult.parsedPipeline.warnings: [PipelineWarning!] { kind, symbol { col, row, text } }
+//   - CompilationResult.resultSchema.fieldList: [{ name }]
+//   - Errors with text=="" mean "compilation requires an input dataset" (not a real syntax error)
+var gqlCheckQueries = compileGqlQuery(
+	`query CheckQueries($queries: MultiStageQueryInput!) {
+		checkQueries(queries: $queries) {
+			parsedPipeline {
+				errors { col row text }
+				warnings { kind symbol { col row } }
+			}
+			resultSchema { fieldList { name } }
+		}
+	}`,
+	"data", "checkQueries", "0",
+)
+
+// opalPos holds row:col position info from the API response.
+type opalPos struct {
+	row string
+	col string
+}
+
+func extractPos(sym any) opalPos {
+	p := opalPos{}
+	if m, ok := sym.(object); ok {
+		if v, ok := m["row"].(string); ok {
+			p.row = v
+		}
+		if v, ok := m["col"].(string); ok {
+			p.col = v
+		}
+	}
+	return p
+}
+
+func cmdOpalCheck(fa FuncArgs) error {
+	var pipeline string
+
+	if flagOpalFile != "" {
+		data, err := os.ReadFile(flagOpalFile)
+		if err != nil {
+			return fmt.Errorf("opal check: could not read file %q: %w", flagOpalFile, err)
+		}
+		pipeline = string(data)
+	} else if len(fa.args) >= 3 {
+		pipeline = fa.args[2]
+	} else {
+		return ObserveError{Msg: "usage: observe opal check <pipeline> | observe opal check --file <path>"}
+	}
+
+	stage := object{
+		"stageID":  "stage-1",
+		"pipeline": pipeline,
+		"input":    array{},
+	}
+	queries := object{
+		"outputStage": "stage-1",
+		"stages":      array{stage},
+	}
+
+	result, err := gqlCheckQueries.query(fa.cfg, fa.op, fa.hc, object{"queries": queries})
+	if err != nil {
+		return err
+	}
+
+	res, ok := result.(object)
+	if !ok {
+		return fmt.Errorf("opal check: unexpected response type")
+	}
+
+	// Extract parsedPipeline
+	pp, _ := res["parsedPipeline"].(object)
+	var errors []object
+	var warnings []object
+
+	if pp != nil {
+		if errList, ok := pp["errors"].(array); ok {
+			for _, e := range errList {
+				if m, ok := e.(object); ok {
+					// Skip errors with empty text — these indicate "compilation requires an input
+					// dataset" and are not real syntax errors in the pipeline itself.
+					if text, _ := m["text"].(string); text != "" {
+						errors = append(errors, m)
+					}
+				}
+			}
+		}
+		if warnList, ok := pp["warnings"].(array); ok {
+			for _, w := range warnList {
+				if m, ok := w.(object); ok {
+					warnings = append(warnings, m)
+				}
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		for _, e := range errors {
+			text, _ := e["text"].(string)
+			row, _ := e["row"].(string)
+			col, _ := e["col"].(string)
+			fmt.Fprintf(fa.op, "ERROR %s:%s: %s\n", row, col, text)
+		}
+		return ObserveError{Msg: "opal check: pipeline has errors"}
+	}
+
+	for _, w := range warnings {
+		kind, _ := w["kind"].(string)
+		sym, _ := w["symbol"].(object)
+		pos := extractPos(sym)
+		fmt.Fprintf(fa.op, "WARN %s %s:%s\n", kind, pos.row, pos.col)
+	}
+
+	// Print OK and optionally the result schema fields
+	fmt.Fprintf(fa.op, "OK\n")
+	if schema, ok := res["resultSchema"].(object); ok {
+		if fields, ok := schema["fieldList"].(array); ok {
+			for _, f := range fields {
+				if fm, ok := f.(object); ok {
+					name, _ := fm["name"].(string)
+					fmt.Fprintf(fa.op, "  %s\n", name)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd_opal_extra_test.go
+++ b/cmd_opal_extra_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// validateIngestResponseHelper builds a mock GraphQL response for validateIngestFilterExpression.
+func validateIngestResponseHelper(diagsJSON string) string {
+	return `{"data":{"validateIngestFilterExpression":` + diagsJSON + `}}`
+}
+
+// TestCmdOpalCheckEmptyPipeline verifies that an empty pipeline string is sent to
+// the API rather than triggering a local usage error.
+func TestCmdOpalCheckEmptyPipeline(t *testing.T) {
+	resp := checkQueriesResponse("[]", "[]", `[]`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", ""}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK for empty pipeline (accepted by API), got: %q", out)
+	}
+}
+
+// TestCmdOpalCheckMultipleErrors verifies that all errors are printed, not just the first.
+func TestCmdOpalCheckMultipleErrors(t *testing.T) {
+	resp := checkQueriesResponse(
+		`[{"col":"1","row":"1","text":"bad_verb"},{"col":"10","row":"1","text":"bad_arg"}]`,
+		"[]",
+		"null",
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "bad stuff"}, fix.hc)
+	})
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "bad_verb") {
+		t.Errorf("expected first error text in output, got: %q", out)
+	}
+	if !strings.Contains(out, "bad_arg") {
+		t.Errorf("expected second error text in output, got: %q", out)
+	}
+}
+
+// TestCmdOpalCheckNetworkError verifies that a network-level failure is surfaced as an error.
+func TestCmdOpalCheckNetworkError(t *testing.T) {
+	// Use a server that immediately returns 500.
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 500, `{"errors":[{"message":"internal server error"}]}`},
+	)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "filter true"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+// errorHttpClient always returns an error (simulates connection failure).
+type errorHttpClient struct{}
+
+func (e *errorHttpClient) Do(req *http.Request) (*http.Response, error) {
+	return nil, &httpDialError{"connection refused"}
+}
+
+type httpDialError struct{ msg string }
+
+func (e *httpDialError) Error() string { return e.msg }
+
+// TestCmdOpalCheckConnectionError verifies behavior when HTTP connection fails.
+func TestCmdOpalCheckConnectionError(t *testing.T) {
+	fix := startFixture(t) // no requests expected
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "filter true"}, &errorHttpClient{})
+	})
+	// The error should surface, not panic internally
+}
+
+// TestCmdOpalVerbsNetworkError verifies that a network failure from opal verbs is surfaced.
+func TestCmdOpalVerbsNetworkError(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 500, `{"errors":[{"message":"internal server error"}]}`},
+	)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "verbs"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+// TestCmdOpalFunctionsNetworkError verifies that a network failure from opal functions is surfaced.
+func TestCmdOpalFunctionsNetworkError(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 500, `{"errors":[{"message":"internal server error"}]}`},
+	)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "functions"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+// TestCmdOpalValidateIngestSuccessEdge verifies successful ingest filter validation.
+func TestCmdOpalValidateIngestSuccessEdge(t *testing.T) {
+	resp := validateIngestResponseHelper(`[]`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	flagOpalDataset = ""
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275", "filter true"}, fix.hc)
+	flagOpalDataset = ""
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output, got: %q", out)
+	}
+}
+
+// TestCmdOpalValidateIngestWarnings verifies that messages from validate-ingest are treated as errors.
+// (The API only returns errors, not warnings, for ingest filter validation.)
+func TestCmdOpalValidateIngestWarnings(t *testing.T) {
+	resp := validateIngestResponseHelper(
+		`[{"message":"some validation message"}]`,
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	flagOpalDataset = ""
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275", "filter true"}, fix.hc)
+	})
+	flagOpalDataset = ""
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	// All messages from validateIngestFilterExpression are treated as errors
+	if !strings.Contains(out, "ERROR") {
+		t.Errorf("expected ERROR for any validateIngest message, got: %q", out)
+	}
+}

--- a/cmd_opal_integration_test.go
+++ b/cmd_opal_integration_test.go
@@ -1,0 +1,327 @@
+//go:build integration
+
+package main
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// integrationOpalConfig returns a *Config using env vars with fallback to hardcoded CI values.
+// Note: defaultSite in cmd_dataset_integration_test.go includes the customer ID prefix which
+// causes a duplicate-prefix URL. We use "observeinc.com" as the bare site domain here since
+// SiteUrl() prepends CustomerIdStr automatically.
+func integrationOpalConfig() *Config {
+	customerId := os.Getenv("OBSERVE_CUSTOMERID")
+	if customerId == "" {
+		customerId = defaultCustomerId
+	}
+	authToken := os.Getenv("OBSERVE_AUTHTOKEN")
+	if authToken == "" {
+		authToken = defaultAuthToken
+	}
+	site := os.Getenv("OBSERVE_SITE")
+	if site == "" {
+		// SiteUrl() prepends CustomerIdStr + ".", so just use the bare domain.
+		site = "observeinc.com"
+	}
+	return &Config{
+		CustomerIdStr: customerId,
+		SiteStr:       site,
+		AuthtokenStr:  authToken,
+	}
+}
+
+// TestIntegrationOpalCheckGoodPipeline validates that "filter true" is accepted
+// by the checkQueries API and returns OK with a resultSchema.
+func TestIntegrationOpalCheckGoodPipeline(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "check", "filter true"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalCheck(fa)
+		if err != nil {
+			t.Logf("opal check returned error: %v", err)
+		}
+	}()
+
+	if recovered != nil {
+		t.Errorf("opal check good pipeline panicked: %v", recovered)
+	}
+
+	out := op.OutputBuf.String()
+	t.Logf("output: %s", out)
+
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output for known-good pipeline, got: %q", out)
+	}
+}
+
+// TestIntegrationOpalCheckBadPipeline validates that "not_a_verb 123" produces
+// an ERROR output with line/column info and exits with code 1.
+func TestIntegrationOpalCheckBadPipeline(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "check", "not_a_verb 123"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalCheck(fa)
+		if err != nil {
+			t.Logf("opal check bad pipeline returned error (expected): %v", err)
+		}
+	}()
+
+	out := op.OutputBuf.String()
+	t.Logf("output: %s", out)
+
+	// Either the error surfaced via panic(exitCode) or via returned error;
+	// in both cases the output should contain ERROR with position info.
+	if recovered != nil {
+		if _, ok := recovered.(int); !ok {
+			t.Errorf("unexpected non-exit panic: %v", recovered)
+		}
+	}
+
+	if !strings.Contains(out, "ERROR") {
+		t.Errorf("expected ERROR output for known-bad pipeline, got: %q", out)
+	}
+	// Line and column info should be present (format: "line:col:")
+	if !strings.Contains(out, ":") {
+		t.Errorf("expected line:col info in ERROR output, got: %q", out)
+	}
+}
+
+// TestIntegrationOpalCheckEmptyPipeline validates that an empty pipeline does not panic.
+func TestIntegrationOpalCheckEmptyPipeline(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "check", ""},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalCheck(fa)
+		if err != nil {
+			t.Logf("opal check empty pipeline error: %v", err)
+		}
+	}()
+
+	out := op.OutputBuf.String()
+	t.Logf("output: %s", out)
+
+	// Must not produce an unhandled non-exit panic
+	if recovered != nil {
+		if _, ok := recovered.(int); !ok {
+			t.Errorf("unexpected non-exit panic for empty pipeline: %v", recovered)
+		}
+	}
+}
+
+// TestIntegrationOpalVerbsReturnsResults validates that verbsAndFunctions returns
+// a non-empty list of verbs including well-known ones like "filter" and "limit".
+func TestIntegrationOpalVerbsReturnsResults(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "verbs"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalVerbs(fa)
+		if err != nil {
+			t.Errorf("opal verbs returned error: %v", err)
+		}
+	}()
+
+	if recovered != nil {
+		t.Errorf("opal verbs panicked: %v", recovered)
+		return
+	}
+
+	out := op.OutputBuf.String()
+	t.Logf("output (first 500 chars): %s", truncate(out, 500))
+
+	if out == "" {
+		t.Error("expected non-empty verbs list")
+	}
+	if !strings.Contains(out, "filter") {
+		t.Errorf("expected 'filter' verb in output, got: %q", truncate(out, 200))
+	}
+	if !strings.Contains(out, "limit") {
+		t.Errorf("expected 'limit' verb in output, got: %q", truncate(out, 200))
+	}
+}
+
+// TestIntegrationOpalFunctionsReturnsResults validates that verbsAndFunctions returns
+// a non-empty list of functions including well-known ones like "count".
+func TestIntegrationOpalFunctionsReturnsResults(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "functions"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalFunctions(fa)
+		if err != nil {
+			t.Errorf("opal functions returned error: %v", err)
+		}
+	}()
+
+	if recovered != nil {
+		t.Errorf("opal functions panicked: %v", recovered)
+		return
+	}
+
+	out := op.OutputBuf.String()
+	t.Logf("output (first 500 chars): %s", truncate(out, 500))
+
+	if out == "" {
+		t.Error("expected non-empty functions list")
+	}
+	if !strings.Contains(out, "count") {
+		t.Errorf("expected 'count' function in output, got: %q", truncate(out, 200))
+	}
+}
+
+// TestIntegrationOpalValidateIngestGoodPipeline validates that "filter true"
+// passes validateIngestFilterExpression against the default Fleet dataset.
+func TestIntegrationOpalValidateIngestGoodPipeline(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	// Set the dataset flag for the validate-ingest call.
+	// Fleet dataset: Default.Observe Agent/Events (ID: 42918275)
+	flagOpalDataset = "42918275"
+	defer func() { flagOpalDataset = "" }()
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "validate-ingest", "filter true"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalValidateIngest(fa)
+		if err != nil {
+			t.Logf("validate-ingest returned error: %v", err)
+		}
+	}()
+
+	out := op.OutputBuf.String()
+	t.Logf("output: %s", out)
+
+	if recovered != nil {
+		t.Errorf("validate-ingest good pipeline panicked: %v", recovered)
+	}
+
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK for known-good ingest filter, got: %q", out)
+	}
+}
+
+// TestIntegrationOpalValidateIngestBadPipeline validates that an invalid expression
+// produces ERROR output from validateIngestFilterExpression.
+func TestIntegrationOpalValidateIngestBadPipeline(t *testing.T) {
+	cfg := integrationOpalConfig()
+	op := NewCaptureOutput()
+	hc := &http.Client{}
+
+	flagOpalDataset = "42918275"
+	defer func() { flagOpalDataset = "" }()
+
+	fa := FuncArgs{
+		cfg:  cfg,
+		fs:   newFs(),
+		op:   op,
+		args: []string{"opal", "validate-ingest", "not_a_valid_filter 999"},
+		hc:   hc,
+	}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		err := cmdOpalValidateIngest(fa)
+		if err != nil {
+			t.Logf("validate-ingest bad pipeline returned error (expected): %v", err)
+		}
+	}()
+
+	out := op.OutputBuf.String()
+	t.Logf("output: %s", out)
+
+	// Expect either ERROR output or an exit-code panic
+	hasError := strings.Contains(out, "ERROR")
+	exitPanic := false
+	if recovered != nil {
+		if _, ok := recovered.(int); ok {
+			exitPanic = true
+		} else {
+			t.Errorf("unexpected non-exit panic: %v", recovered)
+		}
+	}
+
+	if !hasError && !exitPanic {
+		t.Errorf("expected ERROR output or exit panic for invalid ingest filter, got: %q", out)
+	}
+}
+
+// truncate returns the first n characters of s (or s itself if shorter than n).
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/cmd_opal_test.go
+++ b/cmd_opal_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// checkQueriesResponse builds a mock GraphQL response for the checkQueries operation.
+// The API returns an array at checkQueries level; errors use {col, row, text} not {message, severity, symbol}.
+func checkQueriesResponse(errorsJSON, warningsJSON, fieldListJSON string) string {
+	return `{"data":{"checkQueries":[{"parsedPipeline":{"errors":` + errorsJSON + `,"warnings":` + warningsJSON + `},"resultSchema":{"fieldList":` + fieldListJSON + `}}]}}`
+}
+
+func TestCmdOpalCheckSuccess(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, checkQueriesResponse("[]", "[]", `[{"name":"timestamp"},{"name":"log"}]`)},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "filter true"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output, got: %q", out)
+	}
+	if !strings.Contains(out, "timestamp") {
+		t.Errorf("expected schema field 'timestamp' in output, got: %q", out)
+	}
+}
+
+func TestCmdOpalCheckErrors(t *testing.T) {
+	resp := checkQueriesResponse(
+		`[{"col":"1","row":"1","text":"not_a_verb"}]`,
+		"[]",
+		"null",
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "not_a_verb 123"}, fix.hc)
+	})
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "ERROR") {
+		t.Errorf("expected ERROR in output, got: %q", out)
+	}
+	if !strings.Contains(out, "not_a_verb") {
+		t.Errorf("expected error text in output, got: %q", out)
+	}
+}
+
+func TestCmdOpalCheckWarnings(t *testing.T) {
+	resp := checkQueriesResponse(
+		"[]",
+		`[{"kind":"deprecation","symbol":{"col":"1","row":"1"}}]`,
+		"[]",
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "filter true"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "WARN") {
+		t.Errorf("expected WARN in output, got: %q", out)
+	}
+	if !strings.Contains(out, "deprecation") {
+		t.Errorf("expected warning kind in output, got: %q", out)
+	}
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output after warnings, got: %q", out)
+	}
+}
+
+func TestCmdOpalCheckNoArgs(t *testing.T) {
+	fix := startFixture(t)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+func TestCmdOpalCheckUnknownSubcommand(t *testing.T) {
+	fix := startFixture(t)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "bogus"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+func TestCmdOpalCheckFile(t *testing.T) {
+	// This test just verifies the flag path fails gracefully with a bad file (before HTTP call).
+	fix := startFixture(t)
+	flagOpalFile = ""
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "--file", "/nonexistent/path/opal.txt"}, fix.hc)
+	})
+	flagOpalFile = "" // reset after parse so subsequent tests are not affected
+	// No HTTP requests should have been made (error before network call)
+	if fix.rix != 0 {
+		t.Errorf("expected 0 HTTP requests, got %d", fix.rix)
+	}
+}
+
+func TestCmdOpalNoSubcommand(t *testing.T) {
+	fix := startFixture(t)
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal"}, fix.hc)
+	})
+	fix.Assert()
+}
+
+// TestCmdOpalCheckEmptyTextError verifies that errors with empty text (from compilation
+// without an input dataset) are treated as OK rather than as real errors.
+func TestCmdOpalCheckEmptyTextError(t *testing.T) {
+	flagOpalFile = "" // ensure --file flag is not set from a previous test
+	// This simulates what the live API returns for "filter true" without an input dataset.
+	resp := checkQueriesResponse(
+		`[{"col":"0","row":"0","text":""}]`,
+		"[]",
+		"null",
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "check", "filter true"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	// Empty-text errors are skipped; should still print OK
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK for empty-text error (compilation without input), got: %q", out)
+	}
+}

--- a/cmd_opal_validate.go
+++ b/cmd_opal_validate.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+)
+
+// gqlValidateIngestFilter validates an OPAL ingest filter expression against a dataset.
+// The --dataset flag is registered on the parent opal FlagSet as flagOpalDataset (cmd_opal.go).
+//
+// Actual API schema: validateIngestFilterExpression returns [TaskResultError!] where
+// TaskResultError only has { message } (no severity or symbol fields).
+// A null result means the pipeline is valid; a non-empty array means errors.
+var gqlValidateIngestFilter = compileGqlQuery(
+	`query ValidateIngestFilter($pipeline: String!, $sourceDatasetID: ObjectId!) {
+		validateIngestFilterExpression(pipeline: $pipeline, sourceDatasetID: $sourceDatasetID) {
+			message
+		}
+	}`,
+	"data", "validateIngestFilterExpression",
+)
+
+func cmdOpalValidateIngest(fa FuncArgs) error {
+	if flagOpalDataset == "" {
+		return ObserveError{Msg: "usage: observe opal validate-ingest --dataset <dataset-id> <pipeline>"}
+	}
+	if len(fa.args) < 3 {
+		return ObserveError{Msg: "usage: observe opal validate-ingest --dataset <dataset-id> <pipeline>"}
+	}
+	pipeline := fa.args[2]
+
+	result, err := gqlValidateIngestFilter.query(fa.cfg, fa.op, fa.hc, object{
+		"pipeline":        pipeline,
+		"sourceDatasetID": flagOpalDataset,
+	})
+	if err != nil {
+		return err
+	}
+
+	// A null result means valid. A non-empty array means errors.
+	var hasErrors bool
+	if result != nil {
+		diags, ok := result.(array)
+		if !ok {
+			// Single object case
+			if m, ok := result.(object); ok {
+				diags = array{m}
+			}
+		}
+		for _, d := range diags {
+			m, ok := d.(object)
+			if !ok {
+				continue
+			}
+			msg, _ := m["message"].(string)
+			fmt.Fprintf(fa.op, "ERROR: %s\n", msg)
+			hasErrors = true
+		}
+	}
+
+	if hasErrors {
+		return ObserveError{Msg: "opal validate-ingest: pipeline has errors"}
+	}
+	fmt.Fprintf(fa.op, "OK\n")
+	return nil
+}

--- a/cmd_opal_validate_test.go
+++ b/cmd_opal_validate_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// validateIngestResponse builds a mock GraphQL response for validateIngestFilterExpression.
+// The actual API returns only { message } on TaskResultError (no severity or symbol).
+func validateIngestResponse(diagsJSON string) string {
+	return `{"data":{"validateIngestFilterExpression":` + diagsJSON + `}}`
+}
+
+func TestCmdOpalValidateIngestSuccess(t *testing.T) {
+	resp := validateIngestResponse(`[]`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	flagOpalDataset = ""
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275", "filter true"}, fix.hc)
+	flagOpalDataset = "" // reset after parse
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK in output, got: %q", out)
+	}
+}
+
+func TestCmdOpalValidateIngestErrors(t *testing.T) {
+	resp := validateIngestResponse(
+		`[{"message":"1,1: unknown verb \"bad_filter\""}]`,
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	flagOpalDataset = ""
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275", "bad_filter"}, fix.hc)
+	})
+	flagOpalDataset = ""
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "ERROR") {
+		t.Errorf("expected ERROR in output, got: %q", out)
+	}
+	if !strings.Contains(out, "bad_filter") {
+		t.Errorf("expected error message in output, got: %q", out)
+	}
+}
+
+func TestCmdOpalValidateIngestNoDataset(t *testing.T) {
+	fix := startFixture(t)
+	flagOpalDataset = ""
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "filter true"}, fix.hc)
+	})
+	flagOpalDataset = ""
+	fix.Assert()
+}
+
+func TestCmdOpalValidateIngestNoPipeline(t *testing.T) {
+	fix := startFixture(t)
+	flagOpalDataset = ""
+	mustPanic(t, func() {
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275"}, fix.hc)
+	})
+	flagOpalDataset = ""
+	fix.Assert()
+}
+
+func TestCmdOpalValidateIngestNullResponse(t *testing.T) {
+	// Null response means no errors (valid pipeline)
+	resp := validateIngestResponse(`null`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	flagOpalDataset = ""
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "validate-ingest", "--dataset", "42918275", "filter true"}, fix.hc)
+	flagOpalDataset = ""
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "OK") {
+		t.Errorf("expected OK for null (no errors) response, got: %q", out)
+	}
+}

--- a/docs/opal.md
+++ b/docs/opal.md
@@ -1,0 +1,52 @@
+# opal
+
+    observe opal check <pipeline>
+    observe opal check --file <path>
+    observe opal verbs
+    observe opal functions
+    observe opal validate-ingest --dataset <dataset-id> <pipeline>
+
+The opal command provides tools for validating and inspecting OPAL pipelines
+and the functions and verbs available in the OPAL query language.
+
+## Subcommands
+
+### check
+
+    observe opal check <pipeline>
+    observe opal check --file <path>
+
+Validates an OPAL pipeline string using the Observe checkQueries API. On error,
+prints each error as `ERROR line:col: message` and exits with code 1. On
+warnings only, prints each warning as `WARN kind: message` and exits 0. On
+success, prints `OK` and the result schema fields.
+
+### verbs
+
+    observe opal verbs
+
+Lists all OPAL verbs available in the tenant, sorted alphabetically, with their
+category and description, in tab-separated columns.
+
+### functions
+
+    observe opal functions
+
+Lists all OPAL functions available in the tenant, sorted alphabetically, with
+their category, return type, and description, in tab-separated columns.
+
+### validate-ingest
+
+    observe opal validate-ingest --dataset <dataset-id> <pipeline>
+
+Validates an OPAL ingest filter expression against a source dataset using the
+Observe validateIngestFilterExpression API. Uses the same error output format
+as `opal check`.
+
+## Examples
+
+    observe opal check "filter true"
+    observe opal check --file my_pipeline.opal
+    observe opal verbs
+    observe opal functions
+    observe opal validate-ingest --dataset 42918275 "filter FIELDS.severity = 'error'"

--- a/ot_opal.go
+++ b/ot_opal.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// joinCategories converts a categories array value to a comma-separated string.
+// The API returns categories as []string rather than a single string.
+func joinCategories(cats any) string {
+	a, ok := cats.(array)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, len(a))
+	for _, c := range a {
+		if s, ok := c.(string); ok {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// gqlVerbsAndFunctions fetches all OPAL verbs and functions from the tenant.
+// Actual API schema uses "categories" (array of strings) not "category" (single string).
+var gqlVerbsAndFunctions = compileGqlQuery(
+	`query VerbsAndFunctions {
+		verbsAndFunctions {
+			verbs { name description categories }
+			functions { name description categories returnType }
+		}
+	}`,
+	"data", "verbsAndFunctions",
+)
+
+func cmdOpalVerbs(fa FuncArgs) error {
+	result, err := gqlVerbsAndFunctions.query(fa.cfg, fa.op, fa.hc, object{})
+	if err != nil {
+		return err
+	}
+	res, ok := result.(object)
+	if !ok {
+		return fmt.Errorf("opal verbs: unexpected response type")
+	}
+	verbsRaw, _ := res["verbs"].(array)
+
+	type verbEntry struct {
+		name       string
+		categories string
+		desc       string
+	}
+	var verbs []verbEntry
+	for _, v := range verbsRaw {
+		m, ok := v.(object)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		categories := joinCategories(m["categories"])
+		desc, _ := m["description"].(string)
+		verbs = append(verbs, verbEntry{name, categories, desc})
+	}
+	sort.Slice(verbs, func(i, j int) bool {
+		return verbs[i].name < verbs[j].name
+	})
+	for _, v := range verbs {
+		fmt.Fprintf(fa.op, "%s\t%s\t%s\n", v.name, v.categories, v.desc)
+	}
+	return nil
+}
+
+func cmdOpalFunctions(fa FuncArgs) error {
+	result, err := gqlVerbsAndFunctions.query(fa.cfg, fa.op, fa.hc, object{})
+	if err != nil {
+		return err
+	}
+	res, ok := result.(object)
+	if !ok {
+		return fmt.Errorf("opal functions: unexpected response type")
+	}
+	funcsRaw, _ := res["functions"].(array)
+
+	type funcEntry struct {
+		name       string
+		categories string
+		returnType string
+		desc       string
+	}
+	var funcs []funcEntry
+	for _, f := range funcsRaw {
+		m, ok := f.(object)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		categories := joinCategories(m["categories"])
+		returnType, _ := m["returnType"].(string)
+		desc, _ := m["description"].(string)
+		funcs = append(funcs, funcEntry{name, categories, returnType, desc})
+	}
+	sort.Slice(funcs, func(i, j int) bool {
+		return funcs[i].name < funcs[j].name
+	})
+	for _, f := range funcs {
+		fmt.Fprintf(fa.op, "%s\t%s\t%s\t%s\n", f.name, f.categories, f.returnType, f.desc)
+	}
+	return nil
+}

--- a/ot_opal_test.go
+++ b/ot_opal_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// verbsAndFunctionsResponse builds a mock GraphQL response for verbsAndFunctions.
+// The actual API uses "categories" (array) not "category" (single string).
+func verbsAndFunctionsResponse(verbsJSON, functionsJSON string) string {
+	return `{"data":{"verbsAndFunctions":{"verbs":` + verbsJSON + `,"functions":` + functionsJSON + `}}}`
+}
+
+func TestCmdOpalVerbs(t *testing.T) {
+	resp := verbsAndFunctionsResponse(
+		`[{"name":"filter","description":"Filter rows","categories":["Filter"]},{"name":"aggregate","description":"Aggregate rows","categories":["Aggregate"]},{"name":"limit","description":"Limit rows","categories":["Filter"]}]`,
+		`[]`,
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "verbs"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	// Verify sorted alphabetically
+	aggIdx := strings.Index(out, "aggregate")
+	filterIdx := strings.Index(out, "filter")
+	limitIdx := strings.Index(out, "limit")
+	if aggIdx < 0 || filterIdx < 0 || limitIdx < 0 {
+		t.Errorf("expected all verbs in output, got: %q", out)
+	}
+	if !(aggIdx < filterIdx && filterIdx < limitIdx) {
+		t.Errorf("expected alphabetical order (aggregate < filter < limit), got: %q", out)
+	}
+	// Verify tab-separated columns
+	if !strings.Contains(out, "\t") {
+		t.Errorf("expected tab-separated output, got: %q", out)
+	}
+	// Verify category is shown
+	if !strings.Contains(out, "Filter") {
+		t.Errorf("expected category 'Filter' in output, got: %q", out)
+	}
+}
+
+func TestCmdOpalFunctions(t *testing.T) {
+	resp := verbsAndFunctionsResponse(
+		`[]`,
+		`[{"name":"sum","description":"Sum values","categories":["Aggregation"],"returnType":"float64"},{"name":"count","description":"Count rows","categories":["Aggregation"],"returnType":"int64"},{"name":"avg","description":"Average values","categories":["Aggregation"],"returnType":"float64"}]`,
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "functions"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	// Verify sorted alphabetically
+	avgIdx := strings.Index(out, "avg")
+	countIdx := strings.Index(out, "count")
+	sumIdx := strings.Index(out, "sum")
+	if avgIdx < 0 || countIdx < 0 || sumIdx < 0 {
+		t.Errorf("expected all functions in output, got: %q", out)
+	}
+	if !(avgIdx < countIdx && countIdx < sumIdx) {
+		t.Errorf("expected alphabetical order (avg < count < sum), got: %q", out)
+	}
+	// Verify tab-separated columns
+	if !strings.Contains(out, "\t") {
+		t.Errorf("expected tab-separated output, got: %q", out)
+	}
+	// Verify returnType is included
+	if !strings.Contains(out, "float64") {
+		t.Errorf("expected returnType in functions output, got: %q", out)
+	}
+}
+
+func TestCmdOpalVerbsEmpty(t *testing.T) {
+	resp := verbsAndFunctionsResponse(`[]`, `[]`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "verbs"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if out != "" {
+		t.Errorf("expected empty output for empty verbs, got: %q", out)
+	}
+}
+
+func TestCmdOpalFunctionsEmpty(t *testing.T) {
+	resp := verbsAndFunctionsResponse(`[]`, `[]`)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "functions"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if out != "" {
+		t.Errorf("expected empty output for empty functions, got: %q", out)
+	}
+}
+
+// TestCmdOpalVerbsMultipleCategories verifies that verbs with multiple categories
+// display them comma-separated.
+func TestCmdOpalVerbsMultipleCategories(t *testing.T) {
+	resp := verbsAndFunctionsResponse(
+		`[{"name":"aggregate","description":"Aggregate rows","categories":["Metrics","Aggregate"]}]`,
+		`[]`,
+	)
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, resp},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"opal", "verbs"}, fix.hc)
+	fix.Assert()
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "Metrics,Aggregate") {
+		t.Errorf("expected comma-separated categories in output, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `observe opal` subcommands for OPAL pipeline validation and language reference:

| Command | Description |
|---|---|
| `observe opal check <pipeline>` | Lint an OPAL pipeline string using the `checkQueries` API |
| `observe opal check --file <path>` | Lint from a file |
| `observe opal verbs` | List all OPAL verbs with descriptions |
| `observe opal functions` | List all OPAL built-in functions |
| `observe opal validate-ingest --dataset <id> <expr>` | Validate an ingest filter expression |

These commands are useful for CI/CD pipelines that validate OPAL before deploying dataset changes, and for developers looking up OPAL syntax without leaving the terminal.

## GraphQL schema notes (verified against live tenant)

- `checkQueries` result fields: `col`/`row`/`text` (not `line`/`column`/`message`)
- `verbsAndFunctions`: uses `categories []` array (not a `category` string)
- `validateIngestFilterExpression`: returns only `{ message }` (no span info)

## Files

- `cmd_opal.go` — CLI command handlers
- `cmd_opal_validate.go` — ingest validation subcommand
- `ot_opal.go` / `ot_opal_test.go` — GraphQL operations and unit tests
- `cmd_opal_test.go` / `cmd_opal_extra_test.go` — handler unit tests
- `cmd_opal_integration_test.go` — integration tests (build tag: `integration`)
- `cmd_opal_validate_test.go` — validate unit tests
- `docs/opal.md` — usage documentation