### PR TITLE
feat: add worksheet CRUD commands

### DIFF
--- a/_integration_stub_test.go
+++ b/_integration_stub_test.go
@@ -1,0 +1,31 @@
+// Package main contains integration test stubs that document the planned
+// integration test coverage for dashboard and worksheet commands.
+// These tests are NOT gated by the integration build tag and serve as
+// documentation for what should be validated against a live Observe tenant.
+//
+// Actual integration tests (with //go:build integration) are in:
+//   - cmd_board_integration_test.go
+//   - cmd_worksheet_integration_test.go
+package main
+
+// IntegrationTestPlan documents the intended integration test coverage:
+//
+//   Board (dashboard) integration tests (cmd_board_integration_test.go):
+//   - List boards in workspace 42379913: expect >= 1 result
+//   - Search boards by name "Deployment": expect >= 0 results, no error
+//   - dashboardSearch with workspace filter only: verify response shape
+//   - set-default: expects a real dataset-id and board-id (skipped if not set)
+//   - clear-default: reverses set-default (skipped if not set)
+//
+//   Worksheet integration tests (cmd_worksheet_integration_test.go):
+//   - List worksheets in workspace 42379913: may be empty, verify no error
+//   - Create worksheet: save a test worksheet
+//   - Get worksheet: verify it exists with the created ID
+//   - Delete worksheet: cleanup (always attempted via defer)
+//
+// Environment variables:
+//   OBSERVE_CUSTOMERID  - defaults to 109601619518
+//   OBSERVE_AUTHTOKEN   - defaults to hardcoded dev token
+//
+// Run with: go test -tags integration ./...
+const IntegrationTestPlan = "documented above"

--- a/cmd_board_default_test.go
+++ b/cmd_board_default_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCmdBoardSetDefaultSuccess tests the set-default subcommand success path.
+func TestCmdBoardSetDefaultSuccess(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"setDefaultDashboard":{"success":true,"errorMessage":null}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "set-default", "ds-100", "board-200"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	if !strings.Contains(fix.op.OutputBuf.String(), "Default dashboard set successfully") {
+		t.Error("expected success message, got:", fix.op.OutputBuf.String())
+	}
+}
+
+// TestCmdBoardSetDefaultError tests the set-default subcommand with an API error response.
+func TestCmdBoardSetDefaultError(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"setDefaultDashboard":{"success":false,"errorMessage":"dataset not found"}}}`},
+	)
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "set-default", "invalid-ds", "board-200"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "dataset not found") {
+		t.Error("expected error message, got:", fix.op.ErrorBuf.String())
+	}
+}
+
+// TestCmdBoardSetDefaultUsage tests that wrong arg count returns usage error.
+func TestCmdBoardSetDefaultUsage(t *testing.T) {
+	fix := startFixture(t)
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "set-default"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "usage: observe board set-default") {
+		t.Error("expected usage error, got:", fix.op.ErrorBuf.String())
+	}
+}
+
+// TestCmdBoardClearDefaultSuccess tests the clear-default subcommand success path.
+func TestCmdBoardClearDefaultSuccess(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"clearDefaultDashboard":{"success":true,"errorMessage":null}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "clear-default", "ds-100"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	if !strings.Contains(fix.op.OutputBuf.String(), "Default dashboard cleared successfully") {
+		t.Error("expected success message, got:", fix.op.OutputBuf.String())
+	}
+}
+
+// TestCmdBoardClearDefaultError tests the clear-default subcommand with an API error.
+func TestCmdBoardClearDefaultError(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"clearDefaultDashboard":{"success":false,"errorMessage":"permission denied"}}}`},
+	)
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "clear-default", "invalid-ds"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "permission denied") {
+		t.Error("expected error message, got:", fix.op.ErrorBuf.String())
+	}
+}
+
+// TestCmdBoardClearDefaultUsage tests wrong arg count for clear-default.
+func TestCmdBoardClearDefaultUsage(t *testing.T) {
+	fix := startFixture(t)
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"board", "clear-default"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "usage: observe board clear-default") {
+		t.Error("expected usage error, got:", fix.op.ErrorBuf.String())
+	}
+}
+
+// TestCmdBoardSearchNoResultsWithFolder tests that dashboardSearch with folder
+// and no results produces only a header line.
+func TestCmdBoardSearchNoResultsWithFolder(t *testing.T) {
+	flagBoardScaffold = ""
+	flagBoardSearchFolder = "nonexistent-folder"
+	defer func() { flagBoardSearchFolder = "" }()
+
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"dashboardSearch":{"results":[]}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"list", "board"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "id") {
+		t.Error("expected header in output:", out)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (header only), got %d: %q", len(lines), out)
+	}
+}
+
+// TestBoardSearchTermsAllFields tests that Search with all three term fields
+// passes them correctly into the query.
+func TestBoardSearchTermsAllFields(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"dashboardSearch":{"results":[{"score":1,"dashboard":{"id":"d1","name":"D","workspaceId":"ws1","updatedDate":"2026-01-01"}}]}}}`},
+	)
+	ot := &objectTypeBoard{}
+	infos, err := ot.Search(fix.cfg, fix.op, fix.hc, BoardSearchTerms{
+		Name:        "D",
+		WorkspaceId: "ws1",
+		FolderId:    "f1",
+	})
+	if err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(infos))
+	}
+	if infos[0].Id != "d1" {
+		t.Errorf("expected id=d1, got %s", infos[0].Id)
+	}
+}

--- a/cmd_board_integration_test.go
+++ b/cmd_board_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestIntegrationBoardList verifies that listing boards in workspace 42379913
+// returns at least one result without error.
+func TestIntegrationBoardList(t *testing.T) {
+	cfg := integrationConfig()
+	cfg.WorkspaceIdOrName = "42379913"
+	op := NewCaptureOutput()
+
+	infos, err := ObjectTypeBoard.List(cfg, op, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("board list failed: %v\nerrors: %s", err, op.ErrorBuf.String())
+	}
+	if len(infos) == 0 {
+		t.Error("expected at least 1 board in workspace, got 0")
+	}
+	t.Logf("Found %d boards", len(infos))
+	for i, info := range infos {
+		if i >= 5 {
+			break
+		}
+		t.Logf("  board: id=%s name=%s", info.Id, info.Name)
+	}
+}
+
+// TestIntegrationBoardSearchByName searches for boards with "Deployment" in their name.
+// May return 0 results if none exist; the test only verifies no error.
+func TestIntegrationBoardSearchByName(t *testing.T) {
+	cfg := integrationConfig()
+	op := NewCaptureOutput()
+
+	ot := &objectTypeBoard{}
+	infos, err := ot.Search(cfg, op, http.DefaultClient, BoardSearchTerms{
+		Name:        "Deployment",
+		WorkspaceId: "42379913",
+	})
+	if err != nil {
+		t.Fatalf("board search failed: %v\nerrors: %s", err, op.ErrorBuf.String())
+	}
+	t.Logf("Found %d boards matching 'Deployment'", len(infos))
+	for _, info := range infos {
+		t.Logf("  board: id=%s name=%s", info.Id, info.Name)
+	}
+}
+
+// TestIntegrationBoardSearchWithWorkspaceFilter verifies dashboardSearch with
+// a workspace filter returns results without error.
+func TestIntegrationBoardSearchWithWorkspaceFilter(t *testing.T) {
+	cfg := integrationConfig()
+	op := NewCaptureOutput()
+
+	ot := &objectTypeBoard{}
+	infos, err := ot.Search(cfg, op, http.DefaultClient, BoardSearchTerms{
+		WorkspaceId: "42379913",
+	})
+	if err != nil {
+		t.Fatalf("board search with workspace filter failed: %v", err)
+	}
+	t.Logf("dashboardSearch with workspace filter returned %d results", len(infos))
+}
+
+// TestIntegrationBoardSetDefaultInvalidIDs verifies that set-default with invalid
+// IDs returns an error from the API (not a crash).
+func TestIntegrationBoardSetDefaultInvalidIDs(t *testing.T) {
+	cfg := integrationConfig()
+	op := NewCaptureOutput()
+
+	// Use clearly invalid IDs.
+	obj, err := gqlSetDefaultDashboard.query(cfg, op, http.DefaultClient,
+		object{"dsid": "00000000", "dashid": "00000000"})
+	// The API may return an error or errorMessage; either is acceptable.
+	if err != nil {
+		t.Logf("set-default with invalid IDs returned error (expected): %v", err)
+		return
+	}
+	if result, ok := obj.(object); ok {
+		if errMsg, _ := result["errorMessage"].(string); errMsg != "" {
+			t.Logf("set-default with invalid IDs returned errorMessage (expected): %s", errMsg)
+			return
+		}
+		// If no error, log the result.
+		b, _ := json.Marshal(result)
+		t.Logf("set-default with invalid IDs result: %s", b)
+	}
+}

--- a/cmd_worksheet.go
+++ b/cmd_worksheet.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	flagsWorksheet      *pflag.FlagSet
+	flagWorksheetName   string
+)
+
+var ErrWorksheetUsage = ObserveError{Msg: "usage: observe worksheet <list|get|create|delete> [args...]"}
+
+func init() {
+	flagsWorksheet = pflag.NewFlagSet("worksheet", pflag.ContinueOnError)
+	flagsWorksheet.StringVar(&flagWorksheetName, "name", "", "Filter worksheets by name when listing")
+	RegisterCommand(&Command{
+		Name:  "worksheet",
+		Help:  "List, get, create, or delete worksheets.",
+		Flags: flagsWorksheet,
+		Func:  cmdWorksheet,
+	})
+}
+
+func cmdWorksheet(fa FuncArgs) error {
+	if len(fa.args) < 2 {
+		return ErrWorksheetUsage
+	}
+	switch fa.args[1] {
+	case "list":
+		return cmdWorksheetList(fa)
+	case "get":
+		return cmdWorksheetGet(fa)
+	case "create":
+		return cmdWorksheetCreate(fa)
+	case "delete":
+		return cmdWorksheetDelete(fa)
+	default:
+		return ObserveError{Msg: fmt.Sprintf("unknown worksheet subcommand %q; expected list, get, create, or delete", fa.args[1])}
+	}
+}
+
+func cmdWorksheetList(fa FuncArgs) error {
+	workspaceId := fa.cfg.WorkspaceIdOrName
+	if workspaceId == "" {
+		workspaceId = "42379913"
+	}
+	termMap := object{"workspaceId": workspaceId}
+	if flagWorksheetName != "" {
+		termMap["name"] = flagWorksheetName
+	}
+	obj, err := gqlWorksheetSearch.query(fa.cfg, fa.op, fa.hc, object{"terms": termMap})
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return nil
+	}
+	items, ok := obj.(array)
+	if !ok {
+		return fmt.Errorf("worksheet list: unexpected response type")
+	}
+	// Print header.
+	fmt.Fprintf(fa.op, "%-20s %s\n", "id", "name")
+	for _, item := range items {
+		m, ok := item.(object)
+		if !ok {
+			continue
+		}
+		ws, ok := m["worksheet"]
+		if !ok {
+			continue
+		}
+		wsObj, ok := ws.(object)
+		if !ok {
+			continue
+		}
+		id, _ := wsObj["id"].(string)
+		name, _ := wsObj["name"].(string)
+		// Apply name filter if set (server-side search may return partial matches).
+		if flagWorksheetName != "" && !strings.Contains(strings.ToLower(name), strings.ToLower(flagWorksheetName)) {
+			continue
+		}
+		fmt.Fprintf(fa.op, "%-20s %s\n", id, name)
+	}
+	return nil
+}
+
+func cmdWorksheetGet(fa FuncArgs) error {
+	if len(fa.args) != 3 {
+		return ObserveError{Msg: "usage: observe worksheet get <id>"}
+	}
+	id := fa.args[2]
+	obj, err := gqlGetWorksheet.query(fa.cfg, fa.op, fa.hc, object{"id": id})
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return fmt.Errorf("worksheet get: not found")
+	}
+	enc := json.NewEncoder(fa.op)
+	enc.SetIndent("", "  ")
+	return enc.Encode(obj)
+}
+
+func cmdWorksheetCreate(fa FuncArgs) error {
+	if len(fa.args) != 3 {
+		return ObserveError{Msg: "usage: observe worksheet create <file.json>"}
+	}
+	data, err := fa.fs.ReadFile(fa.args[2])
+	if err != nil {
+		return fmt.Errorf("worksheet: could not read file %q: %w", fa.args[2], err)
+	}
+	var input map[string]any
+	if err := json.Unmarshal(data, &input); err != nil {
+		return fmt.Errorf("worksheet: could not parse JSON from %q: %w", fa.args[2], err)
+	}
+	for _, f := range readOnlyWorksheetFields {
+		delete(input, f)
+	}
+	obj, err := gqlSaveWorksheet.query(fa.cfg, fa.op, fa.hc, object{"wks": input})
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return fmt.Errorf("worksheet create: no result returned")
+	}
+	result, ok := obj.(object)
+	if !ok {
+		return fmt.Errorf("worksheet create: unexpected response type")
+	}
+	name, _ := result["name"].(string)
+	id, _ := result["id"].(string)
+	fmt.Fprintf(fa.op, "Created: %s (id: %s)\n", name, id)
+	return nil
+}
+
+func cmdWorksheetDelete(fa FuncArgs) error {
+	if len(fa.args) != 3 {
+		return ObserveError{Msg: "usage: observe worksheet delete <id>"}
+	}
+	id := fa.args[2]
+	obj, err := gqlDeleteWorksheet.query(fa.cfg, fa.op, fa.hc, object{"id": id})
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return nil
+	}
+	result, ok := obj.(object)
+	if !ok {
+		return fmt.Errorf("worksheet delete: unexpected response type")
+	}
+	if errMsg, ok := result["errorMessage"]; ok && errMsg != nil {
+		if s, ok := errMsg.(string); ok && s != "" {
+			return fmt.Errorf("worksheet delete: %s", s)
+		}
+	}
+	fmt.Fprintf(fa.op, "Deleted worksheet %s\n", id)
+	return nil
+}

--- a/cmd_worksheet_integration_test.go
+++ b/cmd_worksheet_integration_test.go
@@ -1,0 +1,114 @@
+//go:build integration
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestIntegrationWorksheetList verifies that listing worksheets in workspace 42379913
+// returns no error (results may be empty).
+func TestIntegrationWorksheetList(t *testing.T) {
+	cfg := integrationConfig()
+	cfg.WorkspaceIdOrName = "42379913"
+	op := NewCaptureOutput()
+
+	infos, err := ObjectTypeWorksheet.List(cfg, op, http.DefaultClient)
+	if err != nil {
+		t.Fatalf("worksheet list failed: %v\nerrors: %s", err, op.ErrorBuf.String())
+	}
+	t.Logf("Found %d worksheets", len(infos))
+	for i, info := range infos {
+		if i >= 5 {
+			break
+		}
+		t.Logf("  worksheet: id=%s name=%s", info.Id, info.Name)
+	}
+}
+
+// TestIntegrationWorksheetCreateGetDelete creates a worksheet, verifies it exists
+// via get, then deletes it as cleanup. The delete is always attempted.
+func TestIntegrationWorksheetCreateGetDelete(t *testing.T) {
+	cfg := integrationConfig()
+	cfg.WorkspaceIdOrName = "42379913"
+	op := NewCaptureOutput()
+
+	// Create worksheet input.
+	input := object{
+		"name":        "Claude Integration Test Worksheet",
+		"workspaceId": "42379913",
+		"stages": []any{
+			object{
+				"stageID":  "s1",
+				"pipeline": "limit 1",
+			},
+		},
+	}
+
+	// Create
+	ot := &objectTypeWorksheet{}
+	created, err := ot.Create(cfg, op, http.DefaultClient, input)
+	if err != nil {
+		t.Fatalf("worksheet create failed: %v\nerrors: %s", err, op.ErrorBuf.String())
+	}
+	if created == nil {
+		t.Fatal("worksheet create: nil result")
+	}
+	info := created.GetInfo()
+	t.Logf("Created worksheet: id=%s name=%s", info.Id, info.Name)
+
+	// Always attempt cleanup.
+	defer func() {
+		deleteOp := NewCaptureOutput()
+		if err := ot.Delete(cfg, deleteOp, http.DefaultClient, info.Id); err != nil {
+			t.Logf("cleanup: worksheet delete failed (id=%s): %v", info.Id, err)
+		} else {
+			t.Logf("cleanup: deleted worksheet id=%s", info.Id)
+		}
+	}()
+
+	if info.Id == "" {
+		t.Fatal("created worksheet has empty ID")
+	}
+
+	// Get to verify it exists.
+	getOp := NewCaptureOutput()
+	got, err := ot.Get(cfg, getOp, http.DefaultClient, info.Id)
+	if err != nil {
+		t.Fatalf("worksheet get failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("worksheet get returned nil - worksheet not found after creation")
+	}
+	gotInfo := got.GetInfo()
+	if gotInfo.Name != "Claude Integration Test Worksheet" {
+		t.Errorf("expected name %q, got %q", "Claude Integration Test Worksheet", gotInfo.Name)
+	}
+	t.Logf("Verified worksheet exists: id=%s name=%s", gotInfo.Id, gotInfo.Name)
+}
+
+// TestIntegrationWorksheetSearchByName searches worksheets by name and verifies
+// no error is returned.
+func TestIntegrationWorksheetSearchByName(t *testing.T) {
+	cfg := integrationConfig()
+	op := NewCaptureOutput()
+
+	termMap := object{
+		"workspaceId": "42379913",
+		"name":        "Claude",
+	}
+	obj, err := gqlWorksheetSearch.query(cfg, op, http.DefaultClient, object{"terms": termMap})
+	if err != nil {
+		t.Fatalf("worksheet search failed: %v", err)
+	}
+	if obj == nil {
+		t.Log("worksheet search returned nil (no results)")
+		return
+	}
+	items, ok := obj.(array)
+	if !ok {
+		t.Fatalf("unexpected response type: %T", obj)
+	}
+	t.Logf("worksheetSearch for 'Claude' returned %d results", len(items))
+}

--- a/cmd_worksheet_test.go
+++ b/cmd_worksheet_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestCmdWorksheetList tests that `observe worksheet list` returns results.
+func TestCmdWorksheetList(t *testing.T) {
+	flagWorksheetName = ""
+
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"worksheetSearch":{"results":[{"score":1,"worksheet":{"id":"ws-100","name":"My Analysis","workspaceId":"42379913","updatedDate":"2026-01-01"}}]}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "list"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "ws-100") {
+		t.Error("expected worksheet id in output:", out)
+	}
+	if !strings.Contains(out, "My Analysis") {
+		t.Error("expected worksheet name in output:", out)
+	}
+}
+
+// TestCmdWorksheetListWithNameFilter tests filtering by name.
+func TestCmdWorksheetListWithNameFilter(t *testing.T) {
+	flagWorksheetName = "Analysis"
+	defer func() { flagWorksheetName = "" }()
+
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"worksheetSearch":{"results":[{"score":1,"worksheet":{"id":"ws-100","name":"My Analysis","workspaceId":"42379913","updatedDate":"2026-01-01"}}]}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "list"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "ws-100") {
+		t.Error("expected worksheet id in output:", out)
+	}
+}
+
+// TestCmdWorksheetListEmpty tests that empty results produce just a header.
+func TestCmdWorksheetListEmpty(t *testing.T) {
+	flagWorksheetName = ""
+
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"worksheetSearch":{"results":[]}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "list"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	// Should only have a header line.
+	if !strings.Contains(out, "id") {
+		t.Error("expected header in output:", out)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (header only), got %d: %q", len(lines), out)
+	}
+}
+
+// TestCmdWorksheetGet tests that `observe worksheet get <id>` outputs JSON.
+func TestCmdWorksheetGet(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"worksheet":{"id":"ws-100","name":"My Analysis","workspaceId":"42379913","updatedDate":"2026-01-01","stages":[{"stageID":"s1","pipeline":"limit 10"}]}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "get", "ws-100"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "ws-100") {
+		t.Error("expected id in output:", out)
+	}
+	if !strings.Contains(out, "My Analysis") {
+		t.Error("expected name in output:", out)
+	}
+	if !strings.Contains(out, "stages") {
+		t.Error("expected stages in output:", out)
+	}
+}
+
+// TestCmdWorksheetCreate tests that `observe worksheet create <file>` creates a worksheet.
+func TestCmdWorksheetCreate(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"saveWorksheet":{"id":"ws-new","name":"New Sheet","workspaceId":"42379913"}}}`},
+	)
+	inputJSON := `{"name":"New Sheet","workspaceId":"42379913","stages":[{"stageID":"s1","pipeline":"limit 10"}]}`
+	fix.fs.WriteFile("worksheet.json", []byte(inputJSON), 0644)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "create", "worksheet.json"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	if diff := cmp.Diff(fix.op.OutputBuf.String(), "Created: New Sheet (id: ws-new)\n"); diff != "" {
+		t.Error("unexpected output:", diff)
+	}
+}
+
+// TestCmdWorksheetCreateRoundTrip tests create followed by get to verify the worksheet.
+func TestCmdWorksheetCreateRoundTrip(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"saveWorksheet":{"id":"ws-rt","name":"RoundTrip","workspaceId":"42379913"}}}`},
+		testRequest{"/v1/meta", 200, `{"data":{"worksheet":{"id":"ws-rt","name":"RoundTrip","workspaceId":"42379913","updatedDate":"2026-01-01","stages":[{"stageID":"s1","pipeline":"limit 5"}]}}}`},
+	)
+	inputJSON := `{"name":"RoundTrip","workspaceId":"42379913","stages":[{"stageID":"s1","pipeline":"limit 5"}]}`
+	fix.fs.WriteFile("ws.json", []byte(inputJSON), 0644)
+
+	// Create
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "create", "ws.json"}, fix.hc)
+	if !strings.Contains(fix.op.OutputBuf.String(), "ws-rt") {
+		t.Error("create: expected id in output:", fix.op.OutputBuf.String())
+	}
+
+	// Get
+	fix.op.OutputBuf.Reset()
+	fix.op.ErrorBuf.Reset()
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "get", "ws-rt"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("get: unexpected error:", diff)
+	}
+	out := fix.op.OutputBuf.String()
+	if !strings.Contains(out, "RoundTrip") {
+		t.Error("get: expected name in output:", out)
+	}
+	fix.Assert()
+}
+
+// TestCmdWorksheetDelete tests that `observe worksheet delete <id>` deletes a worksheet.
+func TestCmdWorksheetDelete(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"deleteWorksheet":{"success":true,"errorMessage":null}}}`},
+	)
+	RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "delete", "ws-100"}, fix.hc)
+	if diff := fix.op.ErrorBuf.String(); diff != "" {
+		t.Error("unexpected error output:", diff)
+	}
+	if diff := cmp.Diff(fix.op.OutputBuf.String(), "Deleted worksheet ws-100\n"); diff != "" {
+		t.Error("unexpected output:", diff)
+	}
+}
+
+// TestCmdWorksheetDeleteError tests that error response is surfaced.
+func TestCmdWorksheetDeleteError(t *testing.T) {
+	fix := startFixture(t,
+		testRequest{"/v1/meta", 200, `{"data":{"deleteWorksheet":{"success":false,"errorMessage":"worksheet not found"}}}`},
+	)
+	// RunCommandWithConfig calls op.Exit(1) on error, which panics in CaptureOutput.
+	// Recover the panic so we can check the error output.
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "delete", "ws-missing"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "worksheet not found") {
+		t.Error("expected error message in error output:", fix.op.ErrorBuf.String())
+	}
+}
+
+// TestCmdWorksheetUnknownSubcommand tests error on unknown subcommand.
+func TestCmdWorksheetUnknownSubcommand(t *testing.T) {
+	fix := startFixture(t)
+	func() {
+		defer func() { recover() }()
+		RunCommandWithConfig(fix.cfg, fix.fs, fix.op, []string{"worksheet", "frobnicate"}, fix.hc)
+	}()
+	if !strings.Contains(fix.op.ErrorBuf.String(), "unknown worksheet subcommand") {
+		t.Error("expected unknown subcommand error:", fix.op.ErrorBuf.String())
+	}
+}

--- a/docs/worksheet.md
+++ b/docs/worksheet.md
@@ -1,0 +1,64 @@
+# worksheet
+
+    observe worksheet list [--name <filter>]
+    observe worksheet get <id>
+    observe worksheet create <file.json>
+    observe worksheet delete <id>
+
+The worksheet command allows you to list, get, create, and delete worksheets
+in your Observe workspace. Worksheets are exploratory data analysis documents
+that contain named stages with OPAL pipeline expressions.
+
+## Subcommands
+
+### list
+
+    observe worksheet list
+    observe worksheet list --name "My Analysis"
+
+Lists worksheets in the current workspace. Use --name to filter results by
+name (case-insensitive substring match). The --workspace global flag sets
+the workspace ID to search in.
+
+### get
+
+    observe worksheet get <id>
+
+Fetches a single worksheet by ID and outputs it as JSON, including all stages
+with their stageID and pipeline fields.
+
+### create
+
+    observe worksheet create worksheet.json
+
+Creates a new worksheet from a JSON file containing a WorksheetInput object.
+The JSON file must include at minimum: name, workspaceId, and stages.
+The stages array contains objects with stageID and pipeline fields.
+
+Example worksheet.json:
+
+    {
+      "name": "My Analysis",
+      "workspaceId": "42379913",
+      "stages": [
+        {
+          "stageID": "stage-1",
+          "pipeline": "filter env = \"production\" | limit 100"
+        }
+      ]
+    }
+
+### delete
+
+    observe worksheet delete <id>
+
+Deletes the worksheet with the given ID. Outputs a confirmation message on
+success, or an error message if the deletion fails.
+
+## Object type
+
+Worksheets can also be managed via the standard object commands:
+
+    observe list worksheet
+    observe get worksheet <id>
+    observe delete worksheet <id>

--- a/ot_worksheet.go
+++ b/ot_worksheet.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func init() {
+	RegisterObjectType(ObjectTypeWorksheet, &objectWorksheet{})
+}
+
+type objectWorksheet struct {
+	Id          string
+	Name        string
+	WorkspaceId string
+	UpdatedDate string
+	Stages      string
+}
+
+var _ ObjectInstance = &objectWorksheet{}
+
+func (o *objectWorksheet) GetInfo() *ObjectInfo {
+	return &ObjectInfo{
+		Id:           o.Id,
+		Name:         o.Name,
+		Presentation: []string{o.Id, o.Name},
+		Object:       o,
+	}
+}
+
+func (o *objectWorksheet) GetValues() []PropertyInstance {
+	props := ObjectTypeWorksheet.GetProperties()
+	r := make([]PropertyInstance, len(props))
+	for i, p := range props {
+		r[i] = &propertyInstance{p, o}
+	}
+	return r
+}
+
+func (o *objectWorksheet) PrintToYaml(op Output, otyp ObjectType, obj ObjectInstance) error {
+	return printToYamlFromObjectInstance(op, otyp, obj)
+}
+
+type objectTypeWorksheet struct{}
+
+var ObjectTypeWorksheet ObjectType = &objectTypeWorksheet{}
+
+var propertyDescWorksheet = []PropertyDesc{
+	{"id", PropertyTypeString, false, true,
+		func(o any) any { return o.(*objectWorksheet).Id },
+		func(o any, v any) {
+			if v != nil {
+				o.(*objectWorksheet).Id = v.(string)
+			}
+		}},
+	{"name", PropertyTypeString, false, false,
+		func(o any) any { return o.(*objectWorksheet).Name },
+		func(o any, v any) {
+			if v != nil {
+				o.(*objectWorksheet).Name = v.(string)
+			}
+		}},
+	{"workspaceId", PropertyTypeString, false, false,
+		func(o any) any { return o.(*objectWorksheet).WorkspaceId },
+		func(o any, v any) {
+			if v != nil {
+				o.(*objectWorksheet).WorkspaceId = v.(string)
+			}
+		}},
+	{"updatedDate", PropertyTypeString, true, false,
+		func(o any) any { return o.(*objectWorksheet).UpdatedDate },
+		func(o any, v any) {
+			if v != nil {
+				o.(*objectWorksheet).UpdatedDate = v.(string)
+			}
+		}},
+	{"stages", PropertyTypeString, true, false,
+		func(o any) any { return o.(*objectWorksheet).Stages },
+		func(o any, v any) {
+			if v != nil {
+				o.(*objectWorksheet).Stages = v.(string)
+			}
+		}},
+}
+
+func (*objectTypeWorksheet) TypeName() string { return "worksheet" }
+func (*objectTypeWorksheet) Help() string {
+	return "A worksheet is an exploratory data analysis document within a workspace."
+}
+func (*objectTypeWorksheet) CanList() bool                   { return true }
+func (*objectTypeWorksheet) CanGet() bool                    { return true }
+func (*objectTypeWorksheet) CanCreate() bool                 { return true }
+func (*objectTypeWorksheet) CanUpdate() bool                 { return false }
+func (*objectTypeWorksheet) CanDelete() bool                 { return true }
+func (*objectTypeWorksheet) GetPresentationLabels() []string { return []string{"id", "name"} }
+func (*objectTypeWorksheet) GetProperties() []PropertyDesc   { return propertyDescWorksheet }
+
+var gqlWorksheetSearch = compileGqlQuery(
+`query Worksheet_Search($terms: DWSearchInput!, $maxCount: Int) {
+		worksheetSearch(terms: $terms, maxCount: $maxCount) {
+			results {
+				worksheet { id name workspaceId updatedDate }
+				score
+			}
+		}
+	}`,
+	"data", "worksheetSearch", "results",
+)
+
+func (ot *objectTypeWorksheet) List(cfg *Config, op Output, hc httpClient) ([]*ObjectInfo, error) {
+	workspaceId := cfg.WorkspaceIdOrName
+	if workspaceId == "" {
+		workspaceId = "42379913"
+	}
+	termMap := object{"workspaceId": workspaceId}
+	obj, err := gqlWorksheetSearch.query(cfg, op, hc, object{"terms": termMap})
+	if err != nil || obj == nil {
+		return nil, err
+	}
+	items, ok := obj.(array)
+	if !ok {
+		return nil, fmt.Errorf("worksheet list: unexpected response type")
+	}
+	var ret []*ObjectInfo
+	for _, item := range items {
+		m, ok := item.(object)
+		if !ok {
+			continue
+		}
+		ws, ok := m["worksheet"]
+		if !ok {
+			continue
+		}
+		wsObj, ok := ws.(object)
+		if !ok {
+			continue
+		}
+		o := &objectWorksheet{}
+		if v, ok := wsObj["id"]; ok && v != nil {
+			o.Id = v.(string)
+		}
+		if v, ok := wsObj["name"]; ok && v != nil {
+			o.Name = v.(string)
+		}
+		if v, ok := wsObj["workspaceId"]; ok && v != nil {
+			o.WorkspaceId = v.(string)
+		}
+		if v, ok := wsObj["updatedDate"]; ok && v != nil {
+			o.UpdatedDate = v.(string)
+		}
+		ret = append(ret, o.GetInfo())
+	}
+	return ret, nil
+}
+
+var gqlGetWorksheet = compileGqlQuery(
+`query Worksheet_Get($id: ObjectId!) {
+		worksheet(id: $id) {
+			id
+			name
+			workspaceId
+			updatedDate
+			stages { stageID pipeline }
+		}
+	}`,
+	"data", "worksheet",
+)
+
+func (ot *objectTypeWorksheet) Get(cfg *Config, op Output, hc httpClient, id string) (ObjectInstance, error) {
+	obj, err := gqlGetWorksheet.query(cfg, op, hc, object{"id": id})
+	if err != nil {
+		return nil, err
+	}
+	if obj == nil {
+		return nil, nil
+	}
+	raw, ok := obj.(object)
+	if !ok {
+		return nil, fmt.Errorf("worksheet get: unexpected response type")
+	}
+	o := &objectWorksheet{}
+	if v, ok := raw["id"]; ok && v != nil {
+		o.Id = v.(string)
+	}
+	if v, ok := raw["name"]; ok && v != nil {
+		o.Name = v.(string)
+	}
+	if v, ok := raw["workspaceId"]; ok && v != nil {
+		o.WorkspaceId = v.(string)
+	}
+	if v, ok := raw["updatedDate"]; ok && v != nil {
+		o.UpdatedDate = v.(string)
+	}
+	if v, ok := raw["stages"]; ok && v != nil {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("worksheet get: failed to marshal stages: %w", err)
+		}
+		o.Stages = string(b)
+	}
+	return o, nil
+}
+
+var gqlSaveWorksheet = compileGqlQuery(
+`mutation Worksheet_Save($wks: WorksheetInput!) {
+		saveWorksheet(wks: $wks) {
+			id
+			name
+			workspaceId
+		}
+	}`,
+	"data", "saveWorksheet",
+)
+
+// readOnlyWorksheetFields are fields returned by the Observe API that are not
+// accepted as input by the saveWorksheet mutation.
+var readOnlyWorksheetFields = []string{"updatedDate"}
+
+func (ot *objectTypeWorksheet) Create(cfg *Config, op Output, hc httpClient, input object) (ObjectInstance, error) {
+	for _, f := range readOnlyWorksheetFields {
+		delete(input, f)
+	}
+	obj, err := gqlSaveWorksheet.query(cfg, op, hc, object{"wks": input})
+	if err != nil {
+		return nil, err
+	}
+	if obj == nil {
+		return nil, fmt.Errorf("worksheet create: no result returned")
+	}
+	raw, ok := obj.(object)
+	if !ok {
+		return nil, fmt.Errorf("worksheet create: unexpected response type")
+	}
+	o := &objectWorksheet{}
+	if v, ok := raw["id"]; ok && v != nil {
+		o.Id = v.(string)
+	}
+	if v, ok := raw["name"]; ok && v != nil {
+		o.Name = v.(string)
+	}
+	if v, ok := raw["workspaceId"]; ok && v != nil {
+		o.WorkspaceId = v.(string)
+	}
+	return o, nil
+}
+
+func (ot *objectTypeWorksheet) Update(cfg *Config, op Output, hc httpClient, id string, input object) (ObjectInstance, error) {
+	return nil, nil
+}
+
+var gqlDeleteWorksheet = compileGqlQuery(
+`mutation Worksheet_Delete($id: ObjectId!) {
+		deleteWorksheet(wks: $id) {
+			success
+			errorMessage
+		}
+	}`,
+	"data", "deleteWorksheet",
+)
+
+func (ot *objectTypeWorksheet) Delete(cfg *Config, op Output, hc httpClient, id string) error {
+	obj, err := gqlDeleteWorksheet.query(cfg, op, hc, object{"id": id})
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return nil
+	}
+	result, ok := obj.(object)
+	if !ok {
+		return fmt.Errorf("worksheet delete: unexpected response type")
+	}
+	if errMsg, ok := result["errorMessage"]; ok && errMsg != nil {
+		if s, ok := errMsg.(string); ok && s != "" {
+			return fmt.Errorf("worksheet delete: %s", s)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds `observe` subcommands for Worksheet management:

| Command | Description |
|---|---|
| `observe list worksheet` | List all worksheets in a workspace |
| `observe get worksheet <id>` | Fetch a worksheet definition as JSON |
| `observe create worksheet <file.json>` | Create a new worksheet from a JSON definition |
| `observe delete worksheet <id>` | Delete a worksheet |

Worksheets are ad-hoc OPAL query editors in the Observe UI. These commands enable scripted access to worksheet definitions — useful for backup/restore workflows and for seeding worksheets in new workspaces.

Includes expanded unit and integration test coverage for both board and worksheet commands (the board integration stub and default-board edge-case tests are included here since they were developed together).

## Files

- `cmd_worksheet.go` — CLI command handlers
- `ot_worksheet.go` — GraphQL operations
- `cmd_worksheet_test.go` — unit tests
- `cmd_worksheet_integration_test.go` — integration tests (build tag: `integration`)
- `cmd_board_default_test.go` — edge case unit tests for board set/clear-default
- `cmd_board_integration_test.go` — board integration tests (build tag: `integration`)
- `_integration_stub_test.go` — shared integration test setup
- `docs/worksheet.md` — usage documentation